### PR TITLE
Fix creaking_heart active state upgrade

### DIFF
--- a/nbt_upgrade_schema/0321_1.21.40.25_beta_to_1.21.60.28_beta.json
+++ b/nbt_upgrade_schema/0321_1.21.40.25_beta_to_1.21.60.28_beta.json
@@ -218,7 +218,7 @@
                     "byte": 0
                 },
                 "new": {
-                    "string": "dormant"
+                    "string": "uprooted"
                 }
             },
             {
@@ -226,7 +226,7 @@
                     "byte": 1
                 },
                 "new": {
-                    "string": "uprooted"
+                    "string": "awake"
                 }
             }
         ],


### PR DESCRIPTION
The current creaking_heart active state upgrade is wrong. It maps an active creaking heart to the unactive variant. This PR fixes that